### PR TITLE
Add an h3 to Install dependencies manually

### DIFF
--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -33,6 +33,8 @@ yarn astro add vercel
 pnpm astro add vercel
 ```
 
+### Install dependencies manually
+
 If you prefer to install the adapter manually instead, complete the following two steps:
 
 1. Install the Vercel adapter to your project’s dependencies using your preferred package manager. If you’re using npm or aren’t sure, run this in the terminal:


### PR DESCRIPTION
## Changes

Added a h3 element to @astro/vercel page for installing dependencies manually

## Testing

Only a change of docs so no testing was required

## Docs

Updated the docs, it was just like fixing a typo
